### PR TITLE
fix: preserve all job fields when updating status and prevent modal c…

### DIFF
--- a/src/JobTracker.jsx
+++ b/src/JobTracker.jsx
@@ -43,18 +43,24 @@ const StatusDropdown = ({ status, onStatusChange, statusOptions }) => {
 
   return (
     <div className="relative" ref={dropdownRef}>      <button
+      type="button"
       className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer ${statusConfig.color}`}
-      onClick={() => setIsOpen(!isOpen)}
+      onClick={(e) => {
+        e.stopPropagation();
+        setIsOpen(!isOpen);
+      }}
     >
       {statusConfig.label}
       <ChevronDown className="h-3 w-3" />
     </button>
       {isOpen && (
-        <div className="absolute right-0 z-10 mt-1 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
+        <div className="absolute right-0 z-[60] mt-1 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
           <div className="py-1">
             {statusOptions.map((option) => (              <button
+                type="button"
                 key={option.value}
-                onClick={() => {
+                onClick={(e) => {
+                  e.stopPropagation();
                   onStatusChange(option.value);
                   setIsOpen(false);
                 }}

--- a/src/api/useJobs.js
+++ b/src/api/useJobs.js
@@ -236,7 +236,7 @@ const useJobs = () => {
   };
   // Update job status (convenience method)
   const updateJobStatus = async (id, newStatus) => {
-    // Find the current job data to preserve required fields
+    // Find the current job data to preserve all fields
     const currentJob = jobs.find(job => job.id === id);
     if (!currentJob) {
       setError(`Job with ID ${id} not found`);
@@ -244,9 +244,15 @@ const useJobs = () => {
     }
     
     return updateJob(id, { 
-      // Include required fields to satisfy server validation
+      // Preserve all existing fields and only update status
       jobTitle: currentJob.jobTitle,
       company: currentJob.company,
+      location: currentJob.location,
+      remoteType: currentJob.remoteType,
+      salaryMin: currentJob.salaryMin,
+      salaryMax: currentJob.salaryMax,
+      jobUrl: currentJob.jobUrl,
+      notes: currentJob.notes,
       status: newStatus,
       lastUpdated: new Date().toISOString().split('T')[0]
     });


### PR DESCRIPTION
…losure

- Fixed updateJobStatus to preserve all job fields (salary, notes, location, etc.) instead of only required fields
- Added type="button" to StatusDropdown buttons to prevent form submission in modal context
- Added e.stopPropagation() to dropdown click handlers to prevent event bubbling
- Increased dropdown z-index to ensure proper layering above modal

🤖 Generated with [Claude Code](https://claude.ai/code)