### PR TITLE
fix: remove static file serving from backend for separate frontend de…

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -265,17 +265,7 @@ app.delete('/api/jobs/:id', async (req, res) => {
   }
 });
 
-// Handle production
-// Serve static assets if in production
-if (process.env.NODE_ENV === 'production') {
-  // Set static folder
-  app.use(express.static(path.join(__dirname, '../build')));
-
-  // Any route that's not the API will be directed to the React app
-  app.get('*', (req, res) => {
-    res.sendFile(path.join(__dirname, '../build/index.html'));
-  });
-}
+// Production mode - API only (frontend served separately)
 
 // Error handling middleware
 app.use(errorHandler);


### PR DESCRIPTION
…ployment

Removed static file serving middleware and catch-all route that was causing ENOENT errors in production when frontend is served separately.

🤖 Generated with [Claude Code](https://claude.ai/code)